### PR TITLE
feat: Add quantity selector to product cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,8 +203,41 @@
     <div id="cart-overlay" class="hidden fixed inset-0 bg-black opacity-50 z-40"></div>
 
 
+    <!-- Modal de Producto (estructura básica) -->
+    <div id="product-modal-popular" class="fixed inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-center z-50 hidden p-4">
+        <div class="bg-white rounded-lg shadow-xl p-6 w-full max-w-2xl max-h-[90vh] overflow-y-auto">
+            <div class="flex justify-between items-center mb-4">
+                <h3 id="modal-product-name-popular" class="text-2xl font-semibold text-gray-800">Nombre del Producto</h3>
+                <button id="close-modal-button-popular" aria-label="Cerrar modal" class="text-gray-600 hover:text-red-500">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-7 h-7">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                </button>
+            </div>
+            <div class="md:flex md:space-x-6">
+                <div class="md:w-1/2 mb-4 md:mb-0">
+                    <img id="modal-product-image-popular" src="https://via.placeholder.com/400x400.png?text=Producto" alt="Imagen del producto" class="w-full h-auto rounded-lg object-cover">
+                </div>
+                <div class="md:w-1/2">
+                    <p id="modal-product-description-popular" class="text-gray-600 mb-4">Descripción detallada del producto...</p>
+                    <p class="text-2xl font-bold text-yellow-600 mb-4" id="modal-product-price-popular">$0.00</p>
+                    <div class="flex items-center space-x-3 mb-4">
+                        <button id="modal-decrease-quantity-popular" aria-label="Disminuir cantidad" class="bg-gray-200 text-gray-700 px-3 py-1 rounded-md hover:bg-gray-300">-</button>
+                        <span id="modal-product-quantity-popular" class="text-lg font-semibold">1</span>
+                        <button id="modal-increase-quantity-popular" aria-label="Aumentar cantidad" class="bg-gray-200 text-gray-700 px-3 py-1 rounded-md hover:bg-gray-300">+</button>
+                    </div>
+                    <button id="modal-add-to-cart-button-popular" class="w-full bg-yellow-500 text-white py-2.5 rounded-md font-semibold hover:bg-yellow-600 transition-colors duration-300">
+                        Agregar al Carrito
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <!-- Scripts -->
     <script src="js/main.js"></script>
     <script src="js/cart.js"></script>
+    <script src="js/modal.js"></script>
+    <script src="js/modal-popular.js"></script>
 </body>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -179,11 +179,16 @@ document.addEventListener('DOMContentLoaded', () => {
                             <p class="text-sm text-gray-600 mb-3 flex-grow">${product.description.length > 60 ? product.description.substring(0, 60) + '...' : product.description}</p>
                             <p class="text-xl font-bold text-yellow-600 mb-4">${formatCurrency(product.price)}</p>
                             <div class="mt-auto">
-                                <button onclick="window.addToCart({id:'${product.id}', name:'${product.name}', price:${product.price}, image:'${product.image}', description:'${product.description}'}, 1)"
+                                <div class="flex items-center justify-center space-x-3 mb-4">
+                                    <button onclick="updateQuantity('${product.id}', -1)" aria-label="Disminuir cantidad" class="bg-gray-200 text-gray-700 px-3 py-1 rounded-md hover:bg-gray-300">-</button>
+                                    <span id="quantity-${product.id}" class="text-lg font-semibold">1</span>
+                                    <button onclick="updateQuantity('${product.id}', 1)" aria-label="Aumentar cantidad" class="bg-gray-200 text-gray-700 px-3 py-1 rounded-md hover:bg-gray-300">+</button>
+                                </div>
+                                <button onclick="window.addToCart({id:'${product.id}', name:'${product.name}', price:${product.price}, image:'${product.image}', description:'${product.description}'}, getQuantity('${product.id}'))"
                                         class="w-full bg-yellow-500 text-white py-2 px-4 rounded-md font-semibold hover:bg-yellow-600 transition-colors duration-300 text-sm">
                                     Agregar al Carrito
                                 </button>
-                                <button onclick="window.openProductModal({id:'${product.id}', name:'${product.name}', price:${product.price}, image:'${product.image}', description:'${product.description}'})"
+                                <button onclick="window.openPopularProductModal({id:'${product.id}', name:'${product.name}', price:${product.price}, image:'${product.image}', description:'${product.description}'})"
                                         class="w-full mt-2 bg-gray-200 text-gray-700 py-2 px-4 rounded-md hover:bg-gray-300 transition-colors duration-300 text-sm">
                                     Ver Más
                                 </button>
@@ -442,7 +447,12 @@ document.addEventListener('DOMContentLoaded', () => {
                     <p class="text-sm text-gray-500 mb-3 flex-grow">${truncatedDescription}</p>
                     <p class="text-2xl font-bold text-yellow-600 mb-5">${formatCurrency(product.price)}</p>
                     <div class="mt-auto space-y-2">
-                        <button onclick="window.addToCart({id:'${product.id}', name:'${product.name}', price:${product.price}, image:'${product.image}', description:'${product.description}'}, 1)"
+                        <div class="flex items-center justify-center space-x-3 mb-2">
+                            <button onclick="updateQuantity('${product.id}', -1)" aria-label="Disminuir cantidad" class="bg-gray-200 text-gray-700 px-3 py-1 rounded-md hover:bg-gray-300">-</button>
+                            <span id="quantity-${product.id}" class="text-lg font-semibold">1</span>
+                            <button onclick="updateQuantity('${product.id}', 1)" aria-label="Aumentar cantidad" class="bg-gray-200 text-gray-700 px-3 py-1 rounded-md hover:bg-gray-300">+</button>
+                        </div>
+                        <button onclick="window.addToCart({id:'${product.id}', name:'${product.name}', price:${product.price}, image:'${product.image}', description:'${product.description}'}, getQuantity('${product.id}'))"
                                 class="w-full bg-yellow-500 text-white py-2.5 px-4 rounded-md font-semibold hover:bg-yellow-600 transition-colors duration-300 text-base">
                             Agregar al Carrito
                         </button>
@@ -533,4 +543,24 @@ if (typeof formatCurrency !== 'function') {
     function formatCurrency(amount) {
         return `$${parseFloat(amount).toFixed(2).replace(/\d(?=(\d{3})+\.)/g, '$&,')}`;
     }
+}
+
+function updateQuantity(productId, change) {
+    const quantityElement = document.getElementById(`quantity-${productId}`);
+    if (quantityElement) {
+        let currentQuantity = parseInt(quantityElement.textContent, 10);
+        currentQuantity += change;
+        if (currentQuantity < 1) {
+            currentQuantity = 1;
+        }
+        quantityElement.textContent = currentQuantity;
+    }
+}
+
+function getQuantity(productId) {
+    const quantityElement = document.getElementById(`quantity-${productId}`);
+    if (quantityElement) {
+        return parseInt(quantityElement.textContent, 10);
+    }
+    return 1; // Default to 1 if not found
 }

--- a/js/modal-popular.js
+++ b/js/modal-popular.js
@@ -1,0 +1,93 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const productModal = document.getElementById('product-modal-popular');
+    const closeModalButton = document.getElementById('close-modal-button-popular');
+
+    // Elementos del modal que se actualizarán
+    const modalProductName = document.getElementById('modal-product-name-popular');
+    const modalProductImage = document.getElementById('modal-product-image-popular');
+    const modalProductDescription = document.getElementById('modal-product-description-popular');
+    const modalProductPrice = document.getElementById('modal-product-price-popular');
+    const modalDecreaseQuantity = document.getElementById('modal-decrease-quantity-popular');
+    const modalProductQuantity = document.getElementById('modal-product-quantity-popular');
+    const modalIncreaseQuantity = document.getElementById('modal-increase-quantity-popular');
+    const modalAddToCartButton = document.getElementById('modal-add-to-cart-button-popular');
+
+    let currentProduct = null;
+    let currentQuantity = 1;
+
+    function openModal(product) {
+        if (!productModal || !product) return;
+        currentProduct = product;
+        currentQuantity = 1; // Reset quantity
+
+        if (modalProductName) modalProductName.textContent = product.name;
+        if (modalProductImage) {
+            modalProductImage.src = product.image || 'https://via.placeholder.com/400x300.png?text=Producto';
+            modalProductImage.alt = product.name;
+        }
+        if (modalProductDescription) modalProductDescription.textContent = product.description || 'Descripción no disponible.';
+        if (modalProductPrice) modalProductPrice.textContent = formatCurrency(product.price);
+        if (modalProductQuantity) modalProductQuantity.textContent = currentQuantity;
+
+        productModal.classList.remove('hidden');
+        productModal.classList.add('flex'); // Asegura que sea visible y centrado
+        document.body.classList.add('modal-open'); // Para evitar scroll del body si es necesario
+    }
+
+    function closeModal() {
+        if (!productModal) return;
+        productModal.classList.add('hidden');
+        productModal.classList.remove('flex');
+        document.body.classList.remove('modal-open');
+        currentProduct = null;
+        currentQuantity = 1;
+    }
+
+    if (closeModalButton) {
+        closeModalButton.addEventListener('click', closeModal);
+    }
+
+    if (productModal) {
+        productModal.addEventListener('click', (event) => {
+            if (event.target === productModal) {
+                closeModal();
+            }
+        });
+    }
+
+    document.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape' && !productModal.classList.contains('hidden')) {
+            closeModal();
+        }
+    });
+
+    if (modalDecreaseQuantity) {
+        modalDecreaseQuantity.addEventListener('click', () => {
+            if (currentQuantity > 1) {
+                currentQuantity--;
+                if (modalProductQuantity) modalProductQuantity.textContent = currentQuantity;
+            }
+        });
+    }
+
+    if (modalIncreaseQuantity) {
+        modalIncreaseQuantity.addEventListener('click', () => {
+            currentQuantity++;
+            if (modalProductQuantity) modalProductQuantity.textContent = currentQuantity;
+        });
+    }
+
+    if (modalAddToCartButton) {
+        modalAddToCartButton.addEventListener('click', () => {
+            if (currentProduct && typeof window.addToCart === 'function') {
+                const productToAdd = { ...currentProduct };
+                window.addToCart(productToAdd, currentQuantity);
+                closeModal();
+            } else {
+                console.error('Producto actual no definido o función addToCart no disponible.');
+            }
+        });
+    }
+
+    window.openPopularProductModal = openModal;
+});


### PR DESCRIPTION
- Adds a quantity selector with '+' and '-' buttons to product cards on the home and catalog pages.
- You can now specify the quantity of a product before adding it to the cart, without opening the 'See More' modal.
- Creates a new modal for popular products on the home page.
- The 'See More' modal on the catalog page remains unchanged.